### PR TITLE
The "quotaMax" was stored into "quotaRemaining" field

### DIFF
--- a/src/MWSMerchantFulfillmentService/Model/ResponseHeaderMetadata.php
+++ b/src/MWSMerchantFulfillmentService/Model/ResponseHeaderMetadata.php
@@ -29,12 +29,12 @@ class MWSMerchantFulfillmentService_Model_ResponseHeaderMetadata {
   private $metadata = array();
 
   public function __construct($requestId = null, $responseContext = null, $timestamp = null,
-                              $quotaMax = null, $quotaMax = null, $quotaResetsAt = null) {
+                              $quotaMax = null, $quotaRemaining = null, $quotaResetsAt = null) {
     $this->metadata[self::REQUEST_ID] = $requestId;
     $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
     $this->metadata[self::TIMESTAMP] = $timestamp;
     $this->metadata[self::QUOTA_MAX] = $quotaMax;
-    $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+    $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
     $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
   }
 


### PR DESCRIPTION
Due to the copy/paste error in Amazon client library during response header metadata creation the value of "quotaMax" field was stored into "quotaRemaining" field.

For library consumer this looks like request never violates hourly quota, but in reality it could.